### PR TITLE
Typos in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ Future setupMyApp() async {
 
 ```dart
 import 'package:crossfire/crossfire.dart';
-import 'package:crossfire_web/crossfire_flutter.dart';
+import 'package:crossfire_flutter/crossfire_flutter.dart'; 
+  // make sure to add this to your pubspec.yaml
+  
 FirebaseConfiguration configuration;
 
 Future setupMyApp() async {
-  var firebase = new FirebaseFlutter();
+  var firebase = new FlutterFirebase();
   await firebase.init(configuration);
   var app = new MyFancyApp();
 }


### PR DESCRIPTION
I think these are typos:
1.` import 'package:crossfire_web/crossfire_flutter.dart'; ` is wrong directory.
2. `FirebaseFlutter` is wrong. `FlutterFirebase` is correct.